### PR TITLE
[8.x] Pin GitHub Actions to commit SHAs and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/pint-fix.yaml
+++ b/.github/workflows/pint-fix.yaml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
           # token: ${{ secrets.PINT }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@643466ad03b726047b3c78b531be5ec7835429ff # 1.0.0
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4
         with:
           commit_message: Fix styling

--- a/.github/workflows/pint-lint.yaml
+++ b/.github/workflows/pint-lint.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check PHP code style issues
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@643466ad03b726047b3c78b531be5ec7835429ff # 1.0.0
         with:
           testMode: true
           verboseMode: true

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -8,6 +8,6 @@ jobs:
   pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: deepakputhraya/action-pr-title@master
+      - uses: deepakputhraya/action-pr-title@077bddd7bdabd0d2b1b25ed0754c7e62e184d7ee # master
         with:
           regex: '^\[\d+\.x\]\s'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: 8.4
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
@@ -34,13 +34,13 @@ jobs:
 
       - name: Get Changelog
         id: changelog
-        uses: statamic/changelog-action@v1
+        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1
         with:
           version: ${{ github.ref }}
 
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -50,7 +50,7 @@ jobs:
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
 
       - name: Upload zip to release
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -60,7 +60,7 @@ jobs:
           asset_content_type: application/tar+gz
 
       - name: Comment on related issues
-        uses: duncanmcclean/post-release-comments@v1.0.6
+        uses: duncanmcclean/post-release-comments@ee2d062e73bd6f0898f36ed892953ed88134cc19 # v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
                 "chart.js": "^4.5.0"
             },
             "devDependencies": {
-                "laravel-vite-plugin": "^1.2.0",
-                "vite": "^6.3.4"
+                "laravel-vite-plugin": "^3.0.0",
+                "vite": "^8.0.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -35,13 +35,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-            "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/types": "^7.28.5"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -51,9 +51,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -64,404 +64,35 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-            "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
-            "cpu": [
-                "ppc64"
-            ],
+        "node_modules/@emnapi/core": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
             "license": "MIT",
             "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-            "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-            "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
-            "cpu": [
-                "arm64"
-            ],
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-            "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-            "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-            "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-            "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-            "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-            "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-            "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-            "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-            "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
-            "cpu": [
-                "mips64el"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-            "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-            "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-            "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-            "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-            "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-            "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-            "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-            "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-            "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-            "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-            "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -477,29 +108,37 @@
             "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
             "license": "MIT"
         },
-        "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-beta.53",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
-            "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
-            "license": "MIT"
-        },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
-            "integrity": "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+            "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
         },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz",
-            "integrity": "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==",
+        "node_modules/@oxc-project/types": {
+            "version": "0.124.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+            "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
             "cpu": [
                 "arm64"
             ],
@@ -507,12 +146,15 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz",
-            "integrity": "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
             "cpu": [
                 "arm64"
             ],
@@ -520,12 +162,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz",
-            "integrity": "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
             "cpu": [
                 "x64"
             ],
@@ -533,25 +178,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz",
-            "integrity": "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==",
-            "cpu": [
-                "arm64"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz",
-            "integrity": "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
             "cpu": [
                 "x64"
             ],
@@ -559,12 +194,15 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz",
-            "integrity": "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+            "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
             "cpu": [
                 "arm"
             ],
@@ -572,25 +210,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz",
-            "integrity": "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==",
-            "cpu": [
-                "arm"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz",
-            "integrity": "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
             "cpu": [
                 "arm64"
             ],
@@ -598,12 +226,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz",
-            "integrity": "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+            "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -611,25 +242,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz",
-            "integrity": "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==",
-            "cpu": [
-                "loong64"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz",
-            "integrity": "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -637,38 +258,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz",
-            "integrity": "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==",
-            "cpu": [
-                "riscv64"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz",
-            "integrity": "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz",
-            "integrity": "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
             "cpu": [
                 "s390x"
             ],
@@ -676,12 +274,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
-            "integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
             "cpu": [
                 "x64"
             ],
@@ -689,12 +290,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz",
-            "integrity": "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+            "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
             "cpu": [
                 "x64"
             ],
@@ -702,12 +306,49 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz",
-            "integrity": "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+            "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.9.2",
+                "@emnapi/runtime": "1.9.2",
+                "@napi-rs/wasm-runtime": "^1.1.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+            "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
             "cpu": [
                 "arm64"
             ],
@@ -715,25 +356,15 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz",
-            "integrity": "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==",
-            "cpu": [
-                "ia32"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz",
-            "integrity": "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+            "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
             "cpu": [
                 "x64"
             ],
@@ -741,140 +372,159 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+            "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+            "license": "MIT"
         },
         "node_modules/@statamic/cms": {
             "resolved": "vendor/statamic/cms/resources/dist-package",
             "link": true
         },
-        "node_modules/@types/estree": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-            "license": "MIT"
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.3.tgz",
-            "integrity": "sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w==",
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+            "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
             "license": "MIT",
             "dependencies": {
-                "@rolldown/pluginutils": "1.0.0-beta.53"
+                "@rolldown/pluginutils": "1.0.0-rc.13"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "vue": "^3.2.25"
             }
         },
+        "node_modules/@vitejs/plugin-vue/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.13",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+            "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+            "license": "MIT"
+        },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
-            "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+            "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.28.5",
-                "@vue/shared": "3.5.26",
-                "entities": "^7.0.0",
+                "@babel/parser": "^7.29.2",
+                "@vue/shared": "3.5.32",
+                "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
-            "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+            "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-core": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-core": "3.5.32",
+                "@vue/shared": "3.5.32"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
-            "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+            "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.28.5",
-                "@vue/compiler-core": "3.5.26",
-                "@vue/compiler-dom": "3.5.26",
-                "@vue/compiler-ssr": "3.5.26",
-                "@vue/shared": "3.5.26",
+                "@babel/parser": "^7.29.2",
+                "@vue/compiler-core": "3.5.32",
+                "@vue/compiler-dom": "3.5.32",
+                "@vue/compiler-ssr": "3.5.32",
+                "@vue/shared": "3.5.32",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.6",
+                "postcss": "^8.5.8",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
-            "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+            "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-dom": "3.5.32",
+                "@vue/shared": "3.5.32"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
-            "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+            "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/shared": "3.5.26"
+                "@vue/shared": "3.5.32"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
-            "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+            "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/reactivity": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/reactivity": "3.5.32",
+                "@vue/shared": "3.5.32"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
-            "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+            "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/reactivity": "3.5.26",
-                "@vue/runtime-core": "3.5.26",
-                "@vue/shared": "3.5.26",
+                "@vue/reactivity": "3.5.32",
+                "@vue/runtime-core": "3.5.32",
+                "@vue/shared": "3.5.32",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
-            "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+            "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-ssr": "3.5.32",
+                "@vue/shared": "3.5.32"
             },
             "peerDependencies": {
-                "vue": "3.5.26"
+                "vue": "3.5.32"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
-            "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+            "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
             "license": "MIT",
             "peer": true
         },
@@ -888,9 +538,9 @@
             }
         },
         "node_modules/chart.js": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
-            "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "license": "MIT",
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
@@ -906,10 +556,19 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/entities": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
-            "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
             "license": "BSD-2-Clause",
             "peer": true,
             "engines": {
@@ -917,46 +576,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/esbuild": {
-            "version": "0.25.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-            "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.5",
-                "@esbuild/android-arm": "0.25.5",
-                "@esbuild/android-arm64": "0.25.5",
-                "@esbuild/android-x64": "0.25.5",
-                "@esbuild/darwin-arm64": "0.25.5",
-                "@esbuild/darwin-x64": "0.25.5",
-                "@esbuild/freebsd-arm64": "0.25.5",
-                "@esbuild/freebsd-x64": "0.25.5",
-                "@esbuild/linux-arm": "0.25.5",
-                "@esbuild/linux-arm64": "0.25.5",
-                "@esbuild/linux-ia32": "0.25.5",
-                "@esbuild/linux-loong64": "0.25.5",
-                "@esbuild/linux-mips64el": "0.25.5",
-                "@esbuild/linux-ppc64": "0.25.5",
-                "@esbuild/linux-riscv64": "0.25.5",
-                "@esbuild/linux-s390x": "0.25.5",
-                "@esbuild/linux-x64": "0.25.5",
-                "@esbuild/netbsd-arm64": "0.25.5",
-                "@esbuild/netbsd-x64": "0.25.5",
-                "@esbuild/openbsd-arm64": "0.25.5",
-                "@esbuild/openbsd-x64": "0.25.5",
-                "@esbuild/sunos-x64": "0.25.5",
-                "@esbuild/win32-arm64": "0.25.5",
-                "@esbuild/win32-ia32": "0.25.5",
-                "@esbuild/win32-x64": "0.25.5"
             }
         },
         "node_modules/estree-walker": {
@@ -967,10 +586,13 @@
             "peer": true
         },
         "node_modules/fdir": {
-            "version": "6.4.5",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-            "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -981,9 +603,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -1015,23 +637,273 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.2.0.tgz",
-            "integrity": "sha512-R0pJ+IcTVeqEMoKz/B2Ij57QVq3sFTABiFmb06gAwFdivbOgsUtuhX6N2MGLEArajrS3U5JbberzwOe7uXHMHQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.0.1.tgz",
+            "integrity": "sha512-Bx8sVcLIaZT1d0eisABcmjQ1GZdJpaXcV66A8RhXGp9JgR3iL8jDnvakVDXuH87Tn5S9KNx3VOhmJZW1CSexOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
+                "tinyglobby": "^0.2.12",
                 "vite-plugin-full-reload": "^1.1.0"
             },
             "bin": {
                 "clean-orphaned-assets": "bin/clean.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^8.0.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/magic-string": {
@@ -1069,9 +941,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -1081,9 +953,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1108,43 +980,37 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.41.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
-            "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+            "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.7"
+                "@oxc-project/types": "=0.124.0",
+                "@rolldown/pluginutils": "1.0.0-rc.15"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.41.1",
-                "@rollup/rollup-android-arm64": "4.41.1",
-                "@rollup/rollup-darwin-arm64": "4.41.1",
-                "@rollup/rollup-darwin-x64": "4.41.1",
-                "@rollup/rollup-freebsd-arm64": "4.41.1",
-                "@rollup/rollup-freebsd-x64": "4.41.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.41.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.41.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.41.1",
-                "@rollup/rollup-linux-arm64-musl": "4.41.1",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.41.1",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.41.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.41.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.41.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.41.1",
-                "@rollup/rollup-linux-x64-gnu": "4.41.1",
-                "@rollup/rollup-linux-x64-musl": "4.41.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.41.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.41.1",
-                "@rollup/rollup-win32-x64-msvc": "4.41.1",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
             }
         },
         "node_modules/source-map-js": {
@@ -1157,13 +1023,13 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -1172,24 +1038,30 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/vite": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+            "version": "8.0.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+            "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.15",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -1198,14 +1070,15 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"
@@ -1214,13 +1087,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -1258,9 +1134,9 @@
             }
         },
         "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1271,17 +1147,17 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
-            "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
+            "version": "3.5.32",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+            "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.5.26",
-                "@vue/compiler-sfc": "3.5.26",
-                "@vue/runtime-dom": "3.5.26",
-                "@vue/server-renderer": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-dom": "3.5.32",
+                "@vue/compiler-sfc": "3.5.32",
+                "@vue/runtime-dom": "3.5.32",
+                "@vue/server-renderer": "3.5.32",
+                "@vue/shared": "3.5.32"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -1295,13 +1171,6 @@
         "vendor/statamic/cms/resources/dist-package": {
             "name": "@statamic/cms",
             "version": "0.0.0",
-            "dependencies": {
-                "@vitejs/plugin-vue": "^6.0.0"
-            }
-        },
-        "vendor/statamic/cms/resources/js/package": {
-            "name": "@statamic/cms",
-            "extraneous": true,
             "dependencies": {
                 "@vitejs/plugin-vue": "^6.0.0"
             }


### PR DESCRIPTION
All GitHub Actions are pinned to specific commit SHAs (with version comments) across every workflow file.

A `.github/dependabot.yml` is added to keep pinned action SHAs up to date automatically via weekly grouped PRs.