### PR TITLE
[8.x] Fix checkout form test to properly resolve nested tags

### DIFF
--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -38,19 +38,17 @@ beforeEach(function () {
 test('can output checkout form', function () {
     fakeCartWithLineItem();
 
-    $this->tag->setParameters([]);
+    $usage = (string) tag('
+        {{ sc:checkout }}
+            <h2>Checkout</h2>
 
-    $this->tag->setContent('
-        <h2>Checkout</h2>
-
-        {{ sc:gateways }}
-            ---
-            {{ name }} - Duncan Cool ({{ config:is-duncan-cool }}) - Haggis - Tatties
-            ---
-        {{ /sc:gateways }}
+            {{ sc:gateways }}
+                ---
+                {{ name }} - Duncan Cool ({{ config:is-duncan-cool }}) - Haggis - Tatties
+                ---
+            {{ /sc:gateways }}
+        {{ /sc:checkout }}
     ');
-
-    $usage = $this->tag->index();
 
     expect($usage)->toContain('Test On-site Gateway - Duncan Cool (yes) - Haggis - Tatties');
     expect($usage)->toContain('<form method="POST" action="http://localhost/!/simple-commerce/checkout"');


### PR DESCRIPTION
This pull request fixes an issue where the `can output checkout form` test was failing because nested Antlers tags weren't being resolved.

This was happening because the test was directly instantiating `CheckoutTags` and calling `index()` on it with content containing `{{ sc:gateways }}`. When tags are called directly like this (outside of Statamic's normal parsing pipeline), nested tags aren't resolved.

This PR fixes it by using the `tag()` helper function which properly parses Antlers templates through Statamic's `Parse::template()` method, ensuring all nested tags are resolved correctly.