### PR TITLE
[8.x] Update Release Workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/dist/**/* linguist-generated=true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, without the v prefix (e.g. 1.2.0)'
+        required: true
+        type: string
 
 permissions: {}
 
@@ -13,17 +16,50 @@ concurrency:
 
 jobs:
   release:
-    name: Prepare & Create Release
+    name: Create Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Create releases and upload assets
-      issues: write # Comment on related issues
-      pull-requests: write # Comment on related PRs
+    environment: Releases
+    permissions: {} # all writes go through the App token; GITHUB_TOKEN needs no scopes
     steps:
-      - name: Checkout code
+      - name: Resolve and validate version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          version="${INPUT_VERSION#v}"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Version must look like 1.2.0 (got: $INPUT_VERSION)"
+            exit 1
+          fi
+
+          if [[ "$BRANCH" =~ ^[0-9]+\.x$ ]] && [ "${version%%.*}" != "${BRANCH%%.*}" ]; then
+            echo "::error::Version $version does not belong on the $BRANCH branch"
+            exit 1
+          fi
+
+          echo "TAG=v$version" >> "$GITHUB_ENV"
+
+      - name: Get release bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write # Comment on related issues
+          permission-pull-requests: write # Comment on related PRs
+
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true # zizmor: ignore[artipacked] App token is needed to push the tag
+
+      - name: Assert tag does not already exist
+        run: |
+          existing="$(git ls-remote --tags origin "$TAG")"
+          [ -z "$existing" ] || { echo "::error::Tag $TAG already exists on remote. Aborting."; exit 1; }
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -32,52 +68,64 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           tools: composer:v2
 
-      - name: Install Composer Dependencies
+      - name: Use Node.js 20.19.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20.19.0
+          package-manager-cache: false
+
+      - name: Install Composer dependencies
         run: composer install
 
-      - name: Install NPM Dependencies
-        run: npm install
+      - name: Install NPM dependencies
+        run: npm ci
 
-      - name: Compile assets
+      - name: Build release assets
         run: npm run build
 
-      - name: Create zip
-        run: tar -czvf dist.tar.gz dist
+      - name: Create the build commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add --force dist
+          git commit -m "Build assets for $TAG"
+
+      - name: Tag and push the build commit
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
 
       - name: Get Changelog
         id: changelog
-        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1
+        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1.0.2
         with:
-          version: ${{ github.ref }}
-
-      - name: Determine prerelease status
-        id: prerelease
-        env:
-          REF: ${{ github.ref }}
-        run: |
-          if [[ "$REF" == *"-alpha"* ]] || [[ "$REF" == *"-beta"* ]]; then
-            echo "flag=--prerelease" >> $GITHUB_OUTPUT
-          else
-            echo "flag=" >> $GITHUB_OUTPUT
-          fi
+          version: ${{ env.TAG }}
 
       - name: Create release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
-          CHANGELOG: ${{ steps.changelog.outputs.text }}
-          PRERELEASE_FLAG: ${{ steps.prerelease.outputs.flag }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.text }}
+          IS_DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
         run: |
-          gh release create "$TAG_NAME" \
-            --title "$TAG_NAME" \
-            --notes "$CHANGELOG" \
-            $PRERELEASE_FLAG \
-            ./dist.tar.gz
+          latest="$IS_DEFAULT_BRANCH"
+          prerelease=false
+          case "$TAG" in
+            *-*) prerelease=true; latest=false ;;
+          esac
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "$RELEASE_NOTES" \
+            --latest="$latest" \
+            --prerelease="$prerelease"
 
       - name: Comment on related issues
         uses: duncanmcclean/post-release-comments@ee2d062e73bd6f0898f36ed892953ed88134cc19 # v1.0.6
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          version: ${{ github.ref }}
+          version: ${{ env.TAG }}
           changelog: ${{ steps.changelog.outputs.text }}

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,6 @@
         }
     },
     "extra": {
-        "download-dist": {
-            "url": "https://github.com/duncanmcclean/simple-commerce/releases/download/{$version}/dist.tar.gz",
-            "path": "dist"
-        },
         "statamic": {
             "name": "Simple Commerce",
             "description": "A simple, yet powerful e-commerce addon for Statamic."
@@ -35,7 +31,6 @@
         "mollie/mollie-api-php": "^2.30.0",
         "moneyphp/money": "^4.0",
         "paypal/paypal-checkout-sdk": "^1.0",
-        "pixelfear/composer-dist-plugin": "^0.1.0",
         "spatie/ignition": "^1.13",
         "statamic/cms": "^6.5",
         "stillat/proteus": "^4.2.1",
@@ -57,7 +52,6 @@
         "process-timeout": 0,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "process-timeout": 0,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
+            "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true
         }
     },


### PR DESCRIPTION
This pull request updates the addon's release workflow, replacing `pixelfear/composer-dist-plugin` (which fetched compiled assets at install time) with a CI-driven release that builds the assets into the released tag itself. Consumers get the built dist inside the Packagist zip — no post-install fetch.

Related: https://github.com/statamic/cms/pull/14804
